### PR TITLE
override native libraries with local ones using LD_LIBRARY_PATH

### DIFF
--- a/src/network/tor_manager.py
+++ b/src/network/tor_manager.py
@@ -200,11 +200,14 @@ class TorManager:
             cmd.extend(extra_args)
         
         try:
+            env_vars = os.environ.copy()
+            env_vars['LD_LIBRARY_PATH'] = self.TOR_DIR
             process = subprocess.Popen(
                 cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                text=True
+                text=True,
+                env=env_vars
             )
             time.sleep(2)
             if process.poll() is not None: 


### PR DESCRIPTION
On GNU/Linux, the tor binary uses the native libraries before the libraries included in the tarball, if native libraries are installed.
Setting LD_LIBRARY_PATH=TOR_DIR overrides this behavior and allows the binary to use the libraries included in the tarball